### PR TITLE
Added a option to hide navigation bar's separator

### DIFF
--- a/Example/Example.swift
+++ b/Example/Example.swift
@@ -481,6 +481,7 @@ final class ExampleApplication: Portal.Application {
                 $0.rightButtonItems = [
                     .textButton(title: "Hello", onTap: .sendMessage(.pong("Hello!"))),
                 ]
+                $0.separatorHidden = true
             },
             style: navigationBarStyleSheet(){ base, navBar in
                 navBar.titleTextColor = .red

--- a/Portal/View/Components/NavigationBar.swift
+++ b/Portal/View/Components/NavigationBar.swift
@@ -30,18 +30,21 @@ public struct NavigationBarProperties<MessageType> {
     public var onBack: MessageType?
     public var leftButtonItems: [NavigationBarButton<MessageType>]?
     public var rightButtonItems: [NavigationBarButton<MessageType>]?
+    public var separatorHidden: Bool
     
     fileprivate init(
         title: NavigationBarTitle<MessageType>? = .none,
         hideBackButtonTitle: Bool = false,
         onBack: MessageType? = .none,
         leftButtonItems: [NavigationBarButton<MessageType>]? = .none,
-        rightButtonItems: [NavigationBarButton<MessageType>]? = .none) {
+        rightButtonItems: [NavigationBarButton<MessageType>]? = .none,
+        separatorHiden: Bool = false) {
         self.title = title
         self.hideBackButtonTitle = hideBackButtonTitle
         self.onBack = onBack
         self.leftButtonItems = leftButtonItems
         self.rightButtonItems = rightButtonItems
+        self.separatorHidden = separatorHiden
     }
     
 }

--- a/Portal/View/UIKit/PortalNavigationController.swift
+++ b/Portal/View/UIKit/PortalNavigationController.swift
@@ -89,6 +89,10 @@ public final class PortalNavigationController<MessageType, CustomComponentRender
         }
         navigationItem.rightBarButtonItems = navigationBar.properties.rightButtonItems.map { $0.map(render) }
         
+        if navigationBar.properties.separatorHidden {
+            self.navigationBar.setBackgroundImage(UIImage(), for: .any, barMetrics: .default)
+            self.navigationBar.shadowImage = UIImage()
+        }
         
         if let title = navigationBar.properties.title {
             let renderer = NavigationBarTitleRenderer(


### PR DESCRIPTION
## Screencast

Separator hidden:
![simulator screen shot may 30 2017 4 13 22 pm](https://cloud.githubusercontent.com/assets/1799612/26600566/f0ce426e-4552-11e7-95b4-d7757d52db2d.png)

Separator not hidden:
![simulator screen shot may 30 2017 4 13 46 pm](https://cloud.githubusercontent.com/assets/1799612/26600579/fab830aa-4552-11e7-8ab8-462c5246321d.png)
