### PR TITLE
Changed hideBackButtonTitle to backButtonTitle

### DIFF
--- a/Example/Views/Shared.swift
+++ b/Example/Views/Shared.swift
@@ -14,7 +14,7 @@ extension ExampleApplication {
         return Portal.navigationBar(
             properties: properties() {
                 $0.title = .text(title)
-                $0.hideBackButtonTitle = false
+                $0.backButtonTitle = "test"
                 $0.rightButtonItems = [
                     .textButton(title: "Hello", onTap: .sendMessage(.pong("Hello!"))),
                 ]

--- a/Portal/View/Components/NavigationBar.swift
+++ b/Portal/View/Components/NavigationBar.swift
@@ -26,19 +26,19 @@ public enum NavigationBarButton<MessageType> {
 public struct NavigationBarProperties<MessageType> {
     
     public var title: NavigationBarTitle<MessageType>?
-    public var hideBackButtonTitle: Bool
+    public var backButtonTitle: String?
     public var onBack: MessageType?
     public var leftButtonItems: [NavigationBarButton<MessageType>]?
     public var rightButtonItems: [NavigationBarButton<MessageType>]?
     
     fileprivate init(
         title: NavigationBarTitle<MessageType>? = .none,
-        hideBackButtonTitle: Bool = false,
+        backButtonTitle: String? = .none,
         onBack: MessageType? = .none,
         leftButtonItems: [NavigationBarButton<MessageType>]? = .none,
         rightButtonItems: [NavigationBarButton<MessageType>]? = .none) {
         self.title = title
-        self.hideBackButtonTitle = hideBackButtonTitle
+        self.backButtonTitle = backButtonTitle
         self.onBack = onBack
         self.leftButtonItems = leftButtonItems
         self.rightButtonItems = rightButtonItems

--- a/Portal/View/UIKit/PortalNavigationController.swift
+++ b/Portal/View/UIKit/PortalNavigationController.swift
@@ -105,8 +105,8 @@ public final class PortalNavigationController<
         
         if let leftButtonItems = navigationBar.properties.leftButtonItems {
             navigationItem.leftBarButtonItems = leftButtonItems.map(render)
-        } else if navigationBar.properties.hideBackButtonTitle {
-            navigationItem.backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: nil, action: nil)
+        } else if let backButtonTitle = navigationBar.properties.backButtonTitle {
+            navigationItem.backBarButtonItem = UIBarButtonItem(title: backButtonTitle, style: .plain, target: nil, action: nil)
         }
         navigationItem.rightBarButtonItems = navigationBar.properties.rightButtonItems.map { $0.map(render) }
         


### PR DESCRIPTION
This PR add the option to set a title to the back button.

- If the title is .none the native iOS behavior is used.
![none](https://user-images.githubusercontent.com/1799612/28342058-c0752482-6bec-11e7-96ca-7f5a0ac0866c.gif)
- if the title is empty ("") the back button has not text.
![empty](https://user-images.githubusercontent.com/1799612/28342061-c448cadc-6bec-11e7-8513-0bc95da23724.gif)
- if the title is not empty ("test") the back button has the text "test" as title.
![pr](https://user-images.githubusercontent.com/1799612/28342066-c8ee9e40-6bec-11e7-8976-d4c8795adc4d.gif)
