### PR TITLE
Refactor image API to avoid loading side effects

### DIFF
--- a/Example/Views/Examples/ImageScreen.swift
+++ b/Example/Views/Examples/ImageScreen.swift
@@ -20,7 +20,7 @@ enum ImageScreen {
             component: container(
                 children: [
                     imageView(
-                        image: Image.loadImage(named: "test")!,
+                        image: .localImage(named: "test"),
                         layout: layout {
                             $0.height = Dimension(value: 50)
                             $0.width = Dimension(value: 50)

--- a/Example/Views/Examples/MapScreen.swift
+++ b/Example/Views/Examples/MapScreen.swift
@@ -15,9 +15,9 @@ enum MapScreen {
     
     static func view() -> View {
         let placemarks = [
-            MapPlacemark(coordinates: Coordinates(latitude: 10, longitude: 10), icon: Image.loadImage(named: "placemark")),
-            MapPlacemark(coordinates: Coordinates(latitude: 15, longitude: 15), icon: Image.loadImage(named: "placemark")),
-            MapPlacemark(coordinates: Coordinates(latitude: 20, longitude: 20), icon: Image.loadImage(named: "placemark"))
+            MapPlacemark(coordinates: Coordinates(latitude: 10, longitude: 10), icon: .localImage(named: "placemark")),
+            MapPlacemark(coordinates: Coordinates(latitude: 15, longitude: 15), icon: .localImage(named: "placemark")),
+            MapPlacemark(coordinates: Coordinates(latitude: 20, longitude: 20), icon: .localImage(named: "placemark"))
         ]
         let properties = MapProperties(
             placemarks: placemarks,

--- a/Portal/AutoGenerated/AutoEquatable.generated.swift
+++ b/Portal/AutoGenerated/AutoEquatable.generated.swift
@@ -124,6 +124,19 @@ public func == (lhs: Border, rhs: Border) -> Bool {
     default: return false
     }
 }
+// MARK: - Image AutoEquatable
+extension Image: Equatable {}
+public func == (lhs: Image, rhs: Image) -> Bool {
+    switch (lhs, rhs) {
+    case (.localImage(let lhs), .localImage(let rhs)):
+        return lhs == rhs
+    case (.blob(let lhs), .blob(let rhs)):
+        if lhs.data != rhs.data { return false }
+        if lhs.size != rhs.size { return false }
+        return true
+    default: return false
+    }
+}
 // MARK: - Margin AutoEquatable
 extension Margin: Equatable {}
 public func == (lhs: Margin, rhs: Margin) -> Bool {

--- a/Portal/AutoGenerated/AutoEquatable.generated.swift
+++ b/Portal/AutoGenerated/AutoEquatable.generated.swift
@@ -131,9 +131,7 @@ public func == (lhs: Image, rhs: Image) -> Bool {
     case (.localImage(let lhs), .localImage(let rhs)):
         return lhs == rhs
     case (.blob(let lhs), .blob(let rhs)):
-        if lhs.data != rhs.data { return false }
-        if lhs.size != rhs.size { return false }
-        return true
+        return lhs == rhs
     default: return false
     }
 }

--- a/Portal/View/Components/Image.swift
+++ b/Portal/View/Components/Image.swift
@@ -8,17 +8,10 @@
 
 import Foundation
 
-public struct Size: AutoEquatable {
-    
-    public var width: UInt
-    public var height: UInt
-    
-}
-
 public enum Image {
     
     case localImage(named: String)
-    case blob(data: Data, size: Size)
+    case blob(data: Data)
     
 }
 

--- a/Portal/View/Components/Image.swift
+++ b/Portal/View/Components/Image.swift
@@ -15,11 +15,14 @@ public struct Size: AutoEquatable {
     
 }
 
-public protocol ImageType {
+public enum Image {
     
-    var size: Size { get }
+    case localImage(named: String)
+    case blob(data: Data, size: Size)
     
 }
+
+extension Image: AutoEquatable {}
 
 public func imageView<MessageType>(
     image: Image,

--- a/Portal/View/Portal.swift
+++ b/Portal/View/Portal.swift
@@ -55,3 +55,10 @@ public protocol Renderer {
     func apply(changeSet: ComponentChangeSet<MessageType>, to containerView: UIView)
         
 }
+
+public struct Size: AutoEquatable {
+    
+    public var width: UInt
+    public var height: UInt
+    
+}

--- a/Portal/View/UIKit/PortalMapView.swift
+++ b/Portal/View/UIKit/PortalMapView.swift
@@ -55,7 +55,15 @@ extension PortalMapView: MKMapViewDelegate {
         else { return .none }
         
         let annotationView = dequeueReusableAnnotationView(for: annotation)
-        annotationView.image = placemark.icon?.asUIImage
+        if let icon = placemark.icon {
+            annotationView.tag = icon.loadUIImage { loadedImage, hash in
+                guard annotationView.tag == hash else { return }
+                annotationView.tag = 0
+                annotationView.image = loadedImage
+            }
+        } else {
+            annotationView.image = .none
+        }
         
         return annotationView
     }

--- a/Portal/View/UIKit/Renderers/ButtonRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ButtonRenderer.swift
@@ -37,11 +37,7 @@ fileprivate extension UIButton {
                 
             case .icon(let maybeIcon):
                 if let icon = maybeIcon {
-                    self.tag = icon.loadUIImage { loadedImage, hash in
-                        guard self.tag == hash else { return }
-                        self.tag = 0
-                        self.setImage(loadedImage, for: .normal)
-                    }
+                    self.load(image: icon) { self.setImage($0, for: .normal) }
                 } else {
                     self.setImage(.none, for: .normal)
                 }

--- a/Portal/View/UIKit/Renderers/ButtonRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ButtonRenderer.swift
@@ -35,9 +35,16 @@ fileprivate extension UIButton {
             case .text(let text):
                 self.setTitle(text, for: .normal)
                 
-            case .icon(let icon):
-                let image = icon.map { $0.asUIImage }
-                self.setImage(image, for: .normal)
+            case .icon(let maybeIcon):
+                if let icon = maybeIcon {
+                    self.tag = icon.loadUIImage { loadedImage, hash in
+                        guard self.tag == hash else { return }
+                        self.tag = 0
+                        self.setImage(loadedImage, for: .normal)
+                    }
+                } else {
+                    self.setImage(.none, for: .normal)
+                }
                 
             case .isActive(let isActive):
                 self.isSelected = isActive

--- a/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
@@ -36,7 +36,7 @@ extension Image {
         case .localImage(let imageName):
             return UIImage.loadFromRegisteredImageBundles(imageName: imageName)
             
-        case .blob(let imageData, _):
+        case .blob(let imageData):
             return UIImage(data: imageData)
             
         }
@@ -70,7 +70,7 @@ extension Image {
             }
             return hashValue
             
-        case .blob(let imageData, _):
+        case .blob(let imageData):
             let hashValue = imageData.hashValue
             imageProcessingQueue.async {
                 let image = UIImage(data: imageData)

--- a/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
@@ -20,11 +20,90 @@ extension UIImageView {
     
 }
 
+extension Image {
+    
+    var asUIImage: UIImage? {
+        switch self {
+            
+        case .localImage(let imageName):
+            return UIImage(named: imageName, in: .main, compatibleWith: .none)
+            
+        case .blob(let imageData, _):
+            return UIImage(data: imageData)
+            
+        }
+    }
+    
+    // Whenever possible image loading should be done off the main thread
+    // because in performance sensitive scenarios loading an image could
+    // cause frame drops.
+    //
+    // Large images compressed using a image format like JPG, need to
+    // decompressed and transformed into bitmaps in order to be displayed
+    // inside a UIImageView. Loading possible large images inside a table
+    // view could make scrolling slugish.
+    //
+    // - Parameter onLoad Callback function that will get called on the
+    // main thread with the loaded image and the hash value returned
+    // by loadUImage
+    // - Returns a hash value that identifies the image to be loaded
+    // which can be used to decided wether to actually display the
+    // image after it has been loaded. One would want to avoid
+    // displaying images that are no longer valid due to UI being
+    // updated.
+    func loadUIImage(_ onLoad: @escaping (UIImage?, Int) -> Void) -> Int {
+        switch self {
+            
+        case .localImage(let imageName):
+            let hashValue = imageName.hashValue
+            imageProcessingQueue.async {
+                let image = UIImage(named: imageName, in: .main, compatibleWith: .none)
+                DispatchQueue.main.async { onLoad(image, hashValue) }
+            }
+            return hashValue
+            
+        case .blob(let imageData, _):
+            let hashValue = imageData.hashValue
+            imageProcessingQueue.async {
+                let image = UIImage(data: imageData)
+                DispatchQueue.main.async { onLoad(image, hashValue) }
+            }
+            return hashValue
+            
+        }
+    }
+    
+}
+
+extension UIImageView {
+    
+    func load(image: Image) {
+        self.tag = image.loadUIImage { loadedImage, hash in
+            guard self.tag == hash else { return }
+            self.tag = 0
+            self.image = loadedImage
+        }
+    }
+    
+}
+
+fileprivate let imageProcessingQueue = DispatchQueue(
+    label: "com.guidomb.Portal.ImageProcessingQueue",
+    qos: .utility,
+    attributes: .concurrent
+)
+
 fileprivate extension UIImageView {
     
     fileprivate func apply(image: PropertyChange<Image?>) {
-        if case .change(let value) = image {
-            self.image = value?.asUIImage
+        guard case .change(let value) = image else { return }
+        
+        switch value {
+        case .some(let image):
+            self.load(image: image)
+            
+        case .none:
+            self.image = .none
         }
     }
     

--- a/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ImageViewRenderer.swift
@@ -99,10 +99,18 @@ extension UIImage {
 extension UIImageView {
     
     func load(image: Image) {
+        load(image: image) { self.image = $0 }
+    }
+    
+}
+
+extension UIView {
+    
+    func load(image: Image, setter: @escaping (UIImage?) -> Void) {
         self.tag = image.loadUIImage { loadedImage, hash in
             guard self.tag == hash else { return }
             self.tag = 0
-            self.image = loadedImage
+            setter(loadedImage)
         }
     }
     

--- a/Portal/View/UIKit/Renderers/NavigationBarTitleRenderer.swift
+++ b/Portal/View/UIKit/Renderers/NavigationBarTitleRenderer.swift
@@ -32,7 +32,9 @@ internal struct NavigationBarTitleRenderer<
             return .none
             
         case .image(let image):
-            navigationItem.titleView = UIImageView(image: image.asUIImage)
+            let titleView = UIImageView()
+            titleView.load(image: image)
+            navigationItem.titleView = titleView
             return .none
             
         case .component(let titleComponent):

--- a/Portal/View/UIKit/Renderers/ProgressRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ProgressRenderer.swift
@@ -43,7 +43,11 @@ fileprivate extension UIProgressView {
                     progressTintColor = color.asUIColor
                     
                 case .image(let image):
-                    progressImage = image.asUIImage
+                    self.tag = image.loadUIImage { loadedImage, hash in
+                        guard self.tag == hash else { return }
+                        self.tag = 0
+                        self.progressImage = loadedImage
+                    }
                 }
 
             case .trackStyle(let trackStyle):
@@ -53,7 +57,11 @@ fileprivate extension UIProgressView {
                     trackTintColor = color.asUIColor
                     
                 case .image(let image):
-                    trackImage = image.asUIImage
+                    self.tag = image.loadUIImage { loadedImage, hash in
+                        guard self.tag == hash else { return }
+                        self.tag = 0
+                        self.trackImage = loadedImage
+                    }
                 }
 
             }

--- a/Portal/View/UIKit/Renderers/ProgressRenderer.swift
+++ b/Portal/View/UIKit/Renderers/ProgressRenderer.swift
@@ -43,11 +43,7 @@ fileprivate extension UIProgressView {
                     progressTintColor = color.asUIColor
                     
                 case .image(let image):
-                    self.tag = image.loadUIImage { loadedImage, hash in
-                        guard self.tag == hash else { return }
-                        self.tag = 0
-                        self.progressImage = loadedImage
-                    }
+                    self.load(image: image) { self.progressImage =  $0 }
                 }
 
             case .trackStyle(let trackStyle):
@@ -57,11 +53,7 @@ fileprivate extension UIProgressView {
                     trackTintColor = color.asUIColor
                     
                 case .image(let image):
-                    self.tag = image.loadUIImage { loadedImage, hash in
-                        guard self.tag == hash else { return }
-                        self.tag = 0
-                        self.trackImage = loadedImage
-                    }
+                    self.load(image: image) { self.trackImage =  $0 }
                 }
 
             }

--- a/Portal/View/UIKit/UIKitRenderable.swift
+++ b/Portal/View/UIKit/UIKitRenderable.swift
@@ -8,67 +8,6 @@
 
 import UIKit
 
-internal protocol UIImageConvertible {
-    
-    var asUIImage: UIImage { get }
-    
-}
-
-public typealias Image = UIImageContainer
-
-public struct UIImageContainer: ImageType, UIImageConvertible {
-    
-    public static func loadImage(named imageName: String, from bundle: Bundle = .main) -> UIImageContainer? {
-        return UIImage(named: imageName, in: bundle, compatibleWith: .none).map(UIImageContainer.init)
-    }
-    
-    public var size: Size {
-        return Size(width: UInt(image.size.width), height: UInt(image.size.height))
-    }
-    
-    public func applyMask(_ mask: UIImageContainer) -> UIImageContainer? {
-        guard let maskRef = mask.asUIImage.cgImage,
-            let provider = mask.asUIImage.cgImage?.dataProvider,
-            let cgImage = image.cgImage else { return .none }
-        
-        let mask = CGImage(
-            maskWidth: maskRef.width,
-            height: maskRef.height,
-            bitsPerComponent: maskRef.bitsPerComponent,
-            bitsPerPixel: maskRef.bitsPerPixel,
-            bytesPerRow: maskRef.bytesPerRow,
-            provider: provider,
-            decode: nil,
-            shouldInterpolate: false
-        )
-        let maskedImage = mask
-            .flatMap(cgImage.masking)
-            .map(UIImage.init)
-            .map(UIImageContainer.init)
-        
-        return maskedImage
-    }
-    
-    var asUIImage: UIImage {
-        return image
-    }
-    
-    fileprivate let image: UIImage
-    
-    public init(image: UIImage) {
-        self.image = image
-    }
-    
-}
-
-extension UIImageContainer: Equatable {
-    
-    public static func == (lhs: UIImageContainer, rhs: UIImageContainer) -> Bool {
-        return lhs.image == rhs.image
-    }
-    
-}
-
 extension StatusBarStyle {
     
     internal var asUIStatusBarStyle: UIStatusBarStyle {

--- a/PortalTests/ImageViewRendererSpec.swift
+++ b/PortalTests/ImageViewRendererSpec.swift
@@ -25,7 +25,10 @@ class ImageViewRendererSpec: QuickSpec {
             var image: Image!
             
             beforeEach {
-                image = Image.loadImage(named: "search.png", from: Bundle(for: ImageViewRendererSpec.self))!
+                Image.unregisterAllImageBundles()
+                Image.registerImageBundle(Bundle(for: ImageViewRendererSpec.self))
+                
+                image = .localImage(named: "search.png")
                 changeSet = ImageViewChangeSet.fullChangeSet(image: image, style: styleSheet(), layout: layout())
             }
             
@@ -34,7 +37,7 @@ class ImageViewRendererSpec: QuickSpec {
                 it("applies 'image' changes") {
                     let imageView = UIImageView()
                     let _: Render<String> = imageView.apply(changeSet: changeSet, layoutEngine: layoutEngine)
-                    expect(imageView.image).to(equal(image.asUIImage))
+                    expect(imageView.image).toEventually(equal(image.asUIImage))
                 }
                 
                 context("when there are optional properties set to .none") {

--- a/PortalTests/PorgressRenderSpec.swift
+++ b/PortalTests/PorgressRenderSpec.swift
@@ -22,13 +22,18 @@ class ProgressRenderSpec: QuickSpec {
         describe(".apply(changeSet: ProgressChangeSet) -> Result") {
             
             var changeSet: ProgressChangeSet!
+            var trackStyleImage: Image!
             
             beforeEach {
+                Image.unregisterAllImageBundles()
+                Image.registerImageBundle(Bundle(for: ProgressRenderSpec.self))
+                
+                trackStyleImage = .localImage(named: "search.png")
                 let progressCounter = ProgressCounter(partial: 5, total: 10)!
                 
                 let progressStyle = progressStyleSheet { base, progress in
                     progress.progressStyle = .color(.red)
-                    progress.trackStyle = .image(Image.loadImage(named: "search.png", from: Bundle(for: ButtonRendererSpec.self))!)
+                    progress.trackStyle = .image(trackStyleImage)
                 }
                 
                 changeSet = ProgressChangeSet.fullChangeSet(
@@ -53,7 +58,7 @@ class ProgressRenderSpec: QuickSpec {
                 it("applies 'trackStyle' property changes") {
                     let progress = UIProgressView()
                     let _: Render<String> = progress.apply(changeSet: changeSet, layoutEngine: layoutEngine)
-                    expect(progress.trackImage).to(equal(Image.loadImage(named: "search.png", from: Bundle(for: ButtonRendererSpec.self))!.asUIImage))
+                    expect(progress.trackImage).toEventually(equal(trackStyleImage.asUIImage))
                 }
                 
                 it("applies 'progressStyle' and 'textSize' property changes") {

--- a/PortalTests/View/UIKit/Renderers/ButtonRendererSpec.swift
+++ b/PortalTests/View/UIKit/Renderers/ButtonRendererSpec.swift
@@ -25,7 +25,10 @@ class ButtonRendererSpec: QuickSpec {
             var buttonIcon: Image!
             
             beforeEach {
-                buttonIcon = Image.loadImage(named: "search.png", from: Bundle(for: ButtonRendererSpec.self))
+                Image.unregisterAllImageBundles()
+                Image.registerImageBundle(Bundle(for: ButtonRendererSpec.self))
+                
+                buttonIcon = .localImage(named: "search.png")
                 
                 let buttonProperties: ButtonProperties<String> = properties {
                     $0.text = "Hello World"
@@ -64,7 +67,7 @@ class ButtonRendererSpec: QuickSpec {
                 it("applies 'icon' property changes") {
                     let button = UIButton()
                     _ = button.apply(changeSet: changeSet, layoutEngine: layoutEngine)
-                    expect(button.currentImage).to(equal(buttonIcon.asUIImage))
+                    expect(button.currentImage).toEventually(equal(buttonIcon.asUIImage))
                 }
                 
                 it("applies 'onTap' property changes") { waitUntil { done in


### PR DESCRIPTION
Image API was changed in order to avoid side effects in the update or
view functions. Also UIKit dependency at the Application level was
removed.

Images now are an enum and image loading is done in the rendering stage
off the main thread to avoid possible performance issues.