### PR TITLE
Add applicationMessage to handle Payments in AppDelegate

### DIFF
--- a/Portal/UIKit/PortalUIApplication.swift
+++ b/Portal/UIKit/PortalUIApplication.swift
@@ -18,7 +18,7 @@ public enum UIApplicationMessage {
     case didBecomeActive(application: UIApplication)
     case willTerminate(application: UIApplication)
     case remoteNotification(RemoteNotification, application: UIApplication)
-    case handle(transaction: SKPaymentTransaction, queue: SKPaymentQueue)
+    case handlePaymentTransaction(SKPaymentTransaction, queue: SKPaymentQueue)
     
 }
 

--- a/Portal/UIKit/PortalUIApplication.swift
+++ b/Portal/UIKit/PortalUIApplication.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import StoreKit
 
 public enum UIApplicationMessage {
     
@@ -17,6 +18,7 @@ public enum UIApplicationMessage {
     case didBecomeActive(application: UIApplication)
     case willTerminate(application: UIApplication)
     case remoteNotification(RemoteNotification, application: UIApplication)
+    case handle(transaction: SKPaymentTransaction, queue: SKPaymentQueue)
     
 }
 


### PR DESCRIPTION
This PR adds a message to the corresponding PaymentQueue method for the AppDelegate (https://developer.apple.com/documentation/storekit/skpaymenttransactionobserver/1506107-paymentqueue)